### PR TITLE
Fix Serializable issues in view scoped beans

### DIFF
--- a/src/main/java/org/osbo/app/backings/Inicio.java
+++ b/src/main/java/org/osbo/app/backings/Inicio.java
@@ -20,7 +20,9 @@ import javax.servlet.http.HttpSession;
  */
 @ViewScoped
 @ManagedBean(name = "inicio")
-public class Inicio {
+public class Inicio implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     public String entrar() {
         System.out.println("entrando nueva version");

--- a/src/main/java/org/osbo/app/backings/Menu.java
+++ b/src/main/java/org/osbo/app/backings/Menu.java
@@ -29,7 +29,9 @@ import javax.servlet.http.HttpSession;
  */
 @ViewScoped
 @ManagedBean(name = "menu")
-public class Menu {
+public class Menu implements java.io.Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     public String getIdsession() throws Exception {
         String id;
@@ -93,7 +95,9 @@ public class Menu {
         FacesContext fc = FacesContext.getCurrentInstance();
 
         HttpSession se = (HttpSession) fc.getExternalContext().getSession(false);
-        se.invalidate();
+        if (se != null) {
+            se.invalidate();
+        }
 
         HttpServletRequest request = (HttpServletRequest) fc.getExternalContext().getRequest();
         HttpServletResponse response = (HttpServletResponse) fc.getExternalContext().getResponse();


### PR DESCRIPTION
## Summary
- make Inicio and Menu beans implement `Serializable`
- guard against `null` HttpSession when closing

## Testing
- `javac @/tmp/sources.txt` *(fails: package javax.faces.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_684487174b588329b30dcadd78d71817